### PR TITLE
Add TUI reporting workflow with stable finding IDs and targeted reports

### DIFF
--- a/codex-rs/core/src/security/mod.rs
+++ b/codex-rs/core/src/security/mod.rs
@@ -131,6 +131,8 @@ pub(crate) struct EvidenceRecord {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct FindingRecord {
+    #[serde(default)]
+    pub id: String,
     pub target: String,
     pub vulnerability: String,
     pub severity: String,
@@ -227,7 +229,7 @@ impl SecuritySessionStateService {
             SecurityToolInventory::disabled(&zap_config)
         };
 
-        let initial_state = if enabled {
+        let mut initial_state = if enabled {
             if let Err(err) = fs::create_dir_all(&evidence_dir).await {
                 tracing::warn!("failed to create security evidence dir: {err}");
             }
@@ -238,7 +240,9 @@ impl SecuritySessionStateService {
             SecuritySessionState::default()
         };
 
-        Self {
+        let normalized_findings = ensure_finding_ids(&mut initial_state.findings);
+
+        let service = Self {
             enabled,
             root_dir,
             evidence_dir,
@@ -248,7 +252,14 @@ impl SecuritySessionStateService {
             zap_config,
             inventory,
             state: Mutex::new(initial_state),
+        };
+
+        if enabled && normalized_findings {
+            let snapshot = service.snapshot().await;
+            let _ = service.persist_state(&snapshot).await;
         }
+
+        service
     }
 
     pub(crate) async fn render_context_fragment(&self, history: &[ResponseItem]) -> Option<String> {
@@ -523,7 +534,7 @@ impl SecuritySessionStateService {
 
     pub(crate) async fn record_finding(
         &self,
-        finding: FindingRecord,
+        mut finding: FindingRecord,
     ) -> Result<SecuritySessionState, FunctionCallError> {
         if !self.enabled {
             return Err(FunctionCallError::RespondToModel(
@@ -532,6 +543,8 @@ impl SecuritySessionStateService {
         }
 
         let mut state = self.state.lock().await;
+        ensure_finding_ids(&mut state.findings);
+        finding.id = next_finding_id(&state.findings);
         state.findings.push(finding);
         let snapshot = state.clone();
         drop(state);
@@ -565,6 +578,7 @@ impl SecuritySessionStateService {
         &self,
         summary: Option<&str>,
         include_evidence: bool,
+        finding_id: Option<&str>,
     ) -> Result<PathBuf, FunctionCallError> {
         if !self.enabled {
             return Err(FunctionCallError::RespondToModel(
@@ -573,18 +587,46 @@ impl SecuritySessionStateService {
         }
 
         let mut snapshot = self.snapshot().await;
+        ensure_finding_ids(&mut snapshot.findings);
+        if let Some(id) = finding_id {
+            let normalized_id = id.trim();
+            if normalized_id.is_empty() {
+                return Err(FunctionCallError::RespondToModel(
+                    "report_write `finding_id` must not be empty".to_string(),
+                ));
+            }
+            let selected = snapshot
+                .findings
+                .iter()
+                .find(|finding| finding.id == normalized_id)
+                .cloned()
+                .ok_or_else(|| {
+                    FunctionCallError::RespondToModel(format!(
+                        "finding `{normalized_id}` was not found in the current security session"
+                    ))
+                })?;
+            snapshot.findings = vec![selected];
+        }
         snapshot.findings.sort_by(|a, b| {
-            (&a.target, &a.vulnerability, &a.severity).cmp(&(
+            (&a.id, &a.target, &a.vulnerability, &a.severity).cmp(&(
+                &b.id,
                 &b.target,
                 &b.vulnerability,
                 &b.severity,
             ))
         });
         let report = render_report_markdown(&snapshot, summary, include_evidence);
-        fs::write(&self.report_path, report).await.map_err(|err| {
+        let output_path = finding_id.map_or_else(
+            || self.report_path.clone(),
+            |id| {
+                self.root_dir
+                    .join(format!("report_{}.md", sanitize_report_id(id)))
+            },
+        );
+        fs::write(&output_path, report).await.map_err(|err| {
             FunctionCallError::RespondToModel(format!("failed to write security report: {err}"))
         })?;
-        Ok(self.report_path.clone())
+        Ok(output_path)
     }
 
     pub(crate) async fn capture_expected_artifacts(
@@ -1014,6 +1056,48 @@ fn sanitize_identifier(input: &str) -> String {
     )
 }
 
+fn sanitize_report_id(input: &str) -> String {
+    let compact = input
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let trimmed = compact.trim_matches('_');
+    if trimmed.is_empty() {
+        "finding".to_string()
+    } else {
+        trimmed.to_ascii_lowercase()
+    }
+}
+
+fn ensure_finding_ids(findings: &mut [FindingRecord]) -> bool {
+    let mut changed = false;
+    for (index, finding) in findings.iter_mut().enumerate() {
+        if finding.id.trim().is_empty() {
+            finding.id = format!("finding-{:04}", index + 1);
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn next_finding_id(existing: &[FindingRecord]) -> String {
+    let mut max = 0usize;
+    for finding in existing {
+        if let Some(suffix) = finding.id.strip_prefix("finding-")
+            && let Ok(parsed) = suffix.parse::<usize>()
+        {
+            max = max.max(parsed);
+        }
+    }
+    format!("finding-{:04}", max + 1)
+}
+
 fn extract_html_title(body: &str) -> Option<String> {
     let title_regex = Regex::new(r"(?is)<title[^>]*>(.*?)</title>").ok()?;
     title_regex
@@ -1101,7 +1185,8 @@ fn render_report_markdown(
     } else {
         for finding in &state.findings {
             lines.push(format!(
-                "- {} on {} [{} / {} / {}]",
+                "- {}: {} on {} [{} / {} / {}]",
+                finding.id,
                 finding.vulnerability,
                 finding.target,
                 finding.severity,
@@ -1201,6 +1286,7 @@ mod tests {
             .expect("scope");
         service
             .record_finding(FindingRecord {
+                id: String::new(),
                 target: "https://example.com".to_string(),
                 vulnerability: "Reflected XSS".to_string(),
                 severity: "high".to_string(),
@@ -1215,7 +1301,7 @@ mod tests {
             .expect("finding");
 
         let report = service
-            .write_report(Some("Automated security assessment"), true)
+            .write_report(Some("Automated security assessment"), true, None)
             .await
             .expect("report");
         let report_contents = std::fs::read_to_string(report).expect("read report");
@@ -1276,6 +1362,38 @@ mod tests {
         let snapshot = service.snapshot().await;
         assert_eq!(snapshot.commands.len(), 1);
         assert_eq!(snapshot.commands[0].cmd, "nmap -p- 127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn security_state_assigns_ids_for_legacy_findings() {
+        let tmp = tempdir().expect("tempdir");
+        let thread_id = ThreadId::default();
+        let root = tmp.path().join("security").join(thread_id.to_string());
+        std::fs::create_dir_all(&root).expect("create root");
+        std::fs::write(
+            root.join("findings.json"),
+            r#"[
+  {
+    "target": "https://example.com",
+    "vulnerability": "Reflected XSS",
+    "severity": "high",
+    "confidence": "confirmed",
+    "evidence": [],
+    "status": "confirmed"
+  }
+]"#,
+        )
+        .expect("seed legacy findings");
+
+        let service = SecuritySessionStateService::new(
+            tmp.path(),
+            &thread_id,
+            true,
+            SecurityZapConfig::default(),
+        )
+        .await;
+        let snapshot = service.snapshot().await;
+        assert_eq!(snapshot.findings[0].id, "finding-0001");
     }
 
     #[test]

--- a/codex-rs/core/src/tools/handlers/security.rs
+++ b/codex-rs/core/src/tools/handlers/security.rs
@@ -113,6 +113,8 @@ struct ReportWriteArgs {
     summary: Option<String>,
     #[serde(default)]
     include_evidence: bool,
+    #[serde(default)]
+    finding_id: Option<String>,
 }
 
 fn default_exec_yield_time_ms() -> u64 {
@@ -439,6 +441,7 @@ impl ToolHandler for RecordFindingHandler {
             .services
             .security_state
             .record_finding(FindingRecord {
+                id: String::new(),
                 target: args.target,
                 vulnerability: args.vulnerability,
                 severity: args.severity,
@@ -478,10 +481,15 @@ impl ToolHandler for ReportWriteHandler {
         let report_path = session
             .services
             .security_state
-            .write_report(args.summary.as_deref(), args.include_evidence)
+            .write_report(
+                args.summary.as_deref(),
+                args.include_evidence,
+                args.finding_id.as_deref(),
+            )
             .await?;
         let output = json!({
             "report_path": report_path,
+            "finding_id": args.finding_id,
         });
         Ok(FunctionToolOutput::from_text(
             serde_json::to_string_pretty(&output).unwrap_or_else(|_| output.to_string()),

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -1046,6 +1046,15 @@ fn create_report_write_tool() -> ToolSpec {
                         ),
                     },
                 ),
+                (
+                    "finding_id".to_string(),
+                    JsonSchema::String {
+                        description: Some(
+                            "Optional finding identifier to write a single-finding report artifact."
+                                .to_string(),
+                        ),
+                    },
+                ),
             ]),
             required: None,
             additional_properties: Some(false.into()),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -274,6 +274,8 @@ use self::agent::spawn_agent_from_existing;
 pub(crate) use self::agent::spawn_op_forwarder;
 mod session_header;
 use self::session_header::SessionHeader;
+mod reporting;
+use self::reporting::ReportTarget;
 mod provider_selection;
 mod skills;
 mod zap_selection;
@@ -4208,6 +4210,14 @@ impl ChatWidget {
             SlashCommand::Skills => {
                 self.open_skills_menu();
             }
+            SlashCommand::Findings => {
+                self.submit_user_message(reporting::findings_prompt().into());
+            }
+            SlashCommand::Report => {
+                self.submit_user_message(
+                    reporting::report_prompt(&ReportTarget::SessionAll).into(),
+                );
+            }
             SlashCommand::Status => {
                 self.add_status_output();
             }
@@ -4445,6 +4455,20 @@ impl ChatWidget {
                         path: prepared_args,
                     });
                 self.bottom_pane.drain_pending_submission_state();
+            }
+            SlashCommand::Report => {
+                let Some((prepared_args, _prepared_elements)) =
+                    self.bottom_pane.prepare_inline_args_submission(false)
+                else {
+                    return;
+                };
+                match reporting::parse_report_target(&prepared_args) {
+                    Ok(target) => {
+                        self.submit_user_message(reporting::report_prompt(&target).into());
+                        self.bottom_pane.drain_pending_submission_state();
+                    }
+                    Err(usage) => self.add_error_message(usage),
+                }
             }
             _ => self.dispatch_command(cmd),
         }

--- a/codex-rs/tui/src/chatwidget/reporting.rs
+++ b/codex-rs/tui/src/chatwidget/reporting.rs
@@ -1,0 +1,41 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ReportTarget {
+    SessionAll,
+    SingleFinding(String),
+}
+
+pub(super) fn parse_report_target(args: &str) -> Result<ReportTarget, String> {
+    let trimmed = args.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("all") {
+        return Ok(ReportTarget::SessionAll);
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    let first = parts.next();
+    let second = parts.next();
+    let trailing = parts.next();
+    if first == Some("finding")
+        && trailing.is_none()
+        && let Some(id) = second
+    {
+        if id.trim().is_empty() {
+            return Err("Usage: /report [all|finding <id>]".to_string());
+        }
+        return Ok(ReportTarget::SingleFinding(id.to_string()));
+    }
+
+    Err("Usage: /report [all|finding <id>]".to_string())
+}
+
+pub(super) fn findings_prompt() -> String {
+    "List every current security finding in this session as concise bullet points using this format: `<finding_id> — <vulnerability> on <target> [<severity>/<confidence>/<status>]`. Do not invent IDs; use recorded finding IDs only. If none exist, say there are no findings.".to_string()
+}
+
+pub(super) fn report_prompt(target: &ReportTarget) -> String {
+    match target {
+        ReportTarget::SessionAll => "Call `report_write` with `include_evidence: true` and no `finding_id`, then respond with the saved `report_path` only.".to_string(),
+        ReportTarget::SingleFinding(id) => format!(
+            "Call `report_write` with `include_evidence: true` and `finding_id: \"{id}\"`, then respond with the saved `report_path` only."
+        ),
+    }
+}

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -6338,6 +6338,76 @@ async fn zap_selection_popup_snapshot() {
     assert_snapshot!("zap_selection_popup", popup);
 }
 
+#[test]
+fn report_inline_args_parser_handles_supported_forms() {
+    assert_eq!(
+        super::reporting::parse_report_target(""),
+        Ok(super::reporting::ReportTarget::SessionAll)
+    );
+    assert_eq!(
+        super::reporting::parse_report_target("all"),
+        Ok(super::reporting::ReportTarget::SessionAll)
+    );
+    assert_eq!(
+        super::reporting::parse_report_target("finding finding-0007"),
+        Ok(super::reporting::ReportTarget::SingleFinding(
+            "finding-0007".to_string()
+        ))
+    );
+}
+
+#[test]
+fn report_inline_args_parser_rejects_invalid_forms() {
+    assert_eq!(
+        super::reporting::parse_report_target("finding"),
+        Err("Usage: /report [all|finding <id>]".to_string())
+    );
+    assert_eq!(
+        super::reporting::parse_report_target("id finding-0001"),
+        Err("Usage: /report [all|finding <id>]".to_string())
+    );
+}
+
+#[tokio::test]
+async fn findings_command_submits_reporting_prompt() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
+    chat.dispatch_command(SlashCommand::Findings);
+
+    let Op::UserTurn { items, .. } = next_submit_op(&mut op_rx) else {
+        panic!("expected Op::UserTurn");
+    };
+    assert_eq!(
+        items,
+        vec![UserInput::Text {
+            text: super::reporting::findings_prompt(),
+            text_elements: Vec::new(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn report_command_with_finding_id_submits_targeted_prompt() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
+    chat.dispatch_command_with_args(
+        SlashCommand::Report,
+        "finding finding-0003".to_string(),
+        Vec::new(),
+    );
+
+    let Op::UserTurn { items, .. } = next_submit_op(&mut op_rx) else {
+        panic!("expected Op::UserTurn");
+    };
+    assert_eq!(
+        items,
+        vec![UserInput::Text {
+            text: super::reporting::report_prompt(&super::reporting::ReportTarget::SingleFinding(
+                "finding-0003".to_string()
+            )),
+            text_elements: Vec::new(),
+        }]
+    );
+}
+
 #[tokio::test]
 async fn provider_command_inline_arg_dispatches_ollama_selection() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -59,6 +59,8 @@ pub enum SlashCommand {
     Settings,
     TestApproval,
     MultiAgents,
+    Findings,
+    Report,
     // Debugging commands.
     #[strum(serialize = "debug-m-drop")]
     MemoryDrop,
@@ -116,6 +118,8 @@ impl SlashCommand {
             SlashCommand::Logout => "log out of Uxarion",
             SlashCommand::Rollout => "print the rollout file path",
             SlashCommand::TestApproval => "test approval request",
+            SlashCommand::Findings => "show current security findings with IDs",
+            SlashCommand::Report => "generate Markdown security reports",
         }
     }
 
@@ -137,6 +141,7 @@ impl SlashCommand {
                 | SlashCommand::Zap
                 | SlashCommand::Fast
                 | SlashCommand::SandboxReadRoot
+                | SlashCommand::Report
         )
     }
 
@@ -179,7 +184,9 @@ impl SlashCommand {
             | SlashCommand::Apps
             | SlashCommand::Feedback
             | SlashCommand::Quit
-            | SlashCommand::Exit => true,
+            | SlashCommand::Exit
+            | SlashCommand::Findings
+            | SlashCommand::Report => true,
             SlashCommand::Rollout => true,
             SlashCommand::TestApproval => true,
             SlashCommand::Realtime => true,

--- a/docs/project/agent-work/reporting-workflow.md
+++ b/docs/project/agent-work/reporting-workflow.md
@@ -1,0 +1,3 @@
+# Reporting workflow implementation note
+
+- `/findings` and `/report` now route through deterministic prompt scaffolds in the TUI, while `report_write` gained optional `finding_id` support so the existing security session state service remains the single writer for both `report.md` and per-finding Markdown artifacts under the same session directory.


### PR DESCRIPTION
### Motivation
- Provide a first usable reporting workflow so users can inspect findings and generate Markdown reports from the TUI without redesigning the security persistence layer. 
- Preserve compatibility with legacy persisted findings that lack IDs and keep the session-wide report artifact while adding per-finding artifacts. 

### Description
- Add stable finding IDs to `FindingRecord` and auto-backfill legacy findings on load via `ensure_finding_ids`, plus `next_finding_id` logic for new findings, and persist back when normalization occurs (`codex-rs/core/src/security/mod.rs`).
- Extend `write_report` to accept an optional `finding_id` and write either the session report (`report.md`) or a per-finding file `report_<id>.md`; include the finding ID in sorting and rendered report output (`codex-rs/core/src/security/mod.rs`).
- Update the report tool handler and tool schema to accept `finding_id` and forward it to the security service; ensure `record_finding` initializes `id` and lets the service assign the stable ID (`codex-rs/core/src/tools/handlers/security.rs`, `codex-rs/core/src/tools/spec.rs`).
- Add a small TUI reporting module `chatwidget/reporting.rs` and wire new slash commands `/findings` and `/report` (supports `all` and `finding <id>`), routing prompts deterministically instead of duplicating reporting logic in the widget (`codex-rs/tui/src/chatwidget/reporting.rs`, `codex-rs/tui/src/chatwidget.rs`, `codex-rs/tui/src/slash_command.rs`).
- Add TUI unit tests for `parse_report_target` and for slash-command dispatch behavior, and a core test to validate legacy finding backfill (`codex-rs/tui/src/chatwidget/tests.rs`, `codex-rs/core/src/security/mod.rs`).
- Add one implementation note at `docs/project/agent-work/reporting-workflow.md` describing the approach and single writer rule for artifacts.

### Testing
- Tried `just fmt` in `codex-rs` but `just` was not available and install was blocked by registry/network restrictions (attempt aborted). 
- Ran `cargo fmt` in `codex-rs` successfully (`cargo fmt`).
- Ran targeted core tests: attempted `cargo test -p codex-core security_state` but the workspace build failed in this environment due to a missing system library dependency (`libcap`) required to build `codex-linux-sandbox`, so full test execution was blocked; a compile-time issue in `record_finding` was fixed during the rollout and `cargo fmt` completed afterwards.
- Ran targeted TUI tests: attempted `cargo test -p codex-tui report_` to exercise the new parsing and dispatch tests, but the same system dependency prevented completing the test run here.

All changes are limited to the listed files and follow the constraint to reuse the existing security state service; no updater, provider-selection, or ZAP subsystems were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f5c2f1a08321a09cac50bdac45b6)