### PR TITLE
Add TUI reporting workflow: stable finding IDs, /findings and /report commands

### DIFF
--- a/codex-rs/core/src/security/mod.rs
+++ b/codex-rs/core/src/security/mod.rs
@@ -131,6 +131,8 @@ pub(crate) struct EvidenceRecord {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct FindingRecord {
+    #[serde(default)]
+    pub id: String,
     pub target: String,
     pub vulnerability: String,
     pub severity: String,
@@ -523,7 +525,7 @@ impl SecuritySessionStateService {
 
     pub(crate) async fn record_finding(
         &self,
-        finding: FindingRecord,
+        mut finding: FindingRecord,
     ) -> Result<SecuritySessionState, FunctionCallError> {
         if !self.enabled {
             return Err(FunctionCallError::RespondToModel(
@@ -532,6 +534,9 @@ impl SecuritySessionStateService {
         }
 
         let mut state = self.state.lock().await;
+        if finding.id.trim().is_empty() {
+            finding.id = format!("finding-{:04}", state.findings.len() + 1);
+        }
         state.findings.push(finding);
         let snapshot = state.clone();
         drop(state);
@@ -585,6 +590,41 @@ impl SecuritySessionStateService {
             FunctionCallError::RespondToModel(format!("failed to write security report: {err}"))
         })?;
         Ok(self.report_path.clone())
+    }
+
+    pub(crate) async fn write_finding_report(
+        &self,
+        finding_id: &str,
+        summary: Option<&str>,
+        include_evidence: bool,
+    ) -> Result<PathBuf, FunctionCallError> {
+        if !self.enabled {
+            return Err(FunctionCallError::RespondToModel(
+                "security state is disabled for this session".to_string(),
+            ));
+        }
+
+        let mut snapshot = self.snapshot().await;
+        let Some(finding) = snapshot
+            .findings
+            .iter()
+            .find(|finding| finding.id == finding_id)
+            .cloned()
+        else {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "security finding `{finding_id}` was not found"
+            )));
+        };
+        snapshot.findings = vec![finding];
+        let report = render_report_markdown(&snapshot, summary, include_evidence);
+        let path = self.root_dir.join(format!(
+            "report-finding-{}.md",
+            sanitize_identifier(finding_id)
+        ));
+        fs::write(&path, report).await.map_err(|err| {
+            FunctionCallError::RespondToModel(format!("failed to write finding report: {err}"))
+        })?;
+        Ok(path)
     }
 
     pub(crate) async fn capture_expected_artifacts(
@@ -810,6 +850,8 @@ async fn load_state_from_disk(
     {
         state.findings = findings;
     }
+
+    ensure_finding_ids(&mut state.findings);
     Some(state)
 }
 
@@ -1014,6 +1056,14 @@ fn sanitize_identifier(input: &str) -> String {
     )
 }
 
+fn ensure_finding_ids(findings: &mut [FindingRecord]) {
+    for (index, finding) in findings.iter_mut().enumerate() {
+        if finding.id.trim().is_empty() {
+            finding.id = format!("finding-{:04}", index + 1);
+        }
+    }
+}
+
 fn extract_html_title(body: &str) -> Option<String> {
     let title_regex = Regex::new(r"(?is)<title[^>]*>(.*?)</title>").ok()?;
     title_regex
@@ -1101,12 +1151,13 @@ fn render_report_markdown(
     } else {
         for finding in &state.findings {
             lines.push(format!(
-                "- {} on {} [{} / {} / {}]",
+                "- {} on {} [{} / {} / {}] ({})",
                 finding.vulnerability,
                 finding.target,
                 finding.severity,
                 finding.confidence,
-                finding.status
+                finding.status,
+                finding.id
             ));
             if let Some(impact) = &finding.impact {
                 lines.push(format!("  Impact: {impact}"));
@@ -1201,6 +1252,7 @@ mod tests {
             .expect("scope");
         service
             .record_finding(FindingRecord {
+                id: String::new(),
                 target: "https://example.com".to_string(),
                 vulnerability: "Reflected XSS".to_string(),
                 severity: "high".to_string(),
@@ -1220,9 +1272,31 @@ mod tests {
             .expect("report");
         let report_contents = std::fs::read_to_string(report).expect("read report");
         assert!(report_contents.contains("Reflected XSS"));
+        assert!(report_contents.contains("finding-0001"));
 
         let state_contents = std::fs::read_to_string(&service.state_path).expect("read state");
         assert!(state_contents.contains("Reflected XSS"));
+        assert!(state_contents.contains("finding-0001"));
+    }
+
+    #[tokio::test]
+    async fn load_state_backfills_missing_finding_ids() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp
+            .path()
+            .join("security")
+            .join(ThreadId::default().to_string());
+        std::fs::create_dir_all(&root).expect("create root");
+        let findings_path = root.join("findings.json");
+        std::fs::write(
+            &findings_path,
+            r#"[{"target":"https://example.com","vulnerability":"XSS","severity":"high","confidence":"confirmed","status":"confirmed","evidence":[]}]"#,
+        )
+        .expect("write findings");
+        let state = load_state_from_disk(&root.join("state.json"), &findings_path)
+            .await
+            .expect("state");
+        assert_eq!(state.findings[0].id, "finding-0001");
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/tools/handlers/security.rs
+++ b/codex-rs/core/src/tools/handlers/security.rs
@@ -91,6 +91,8 @@ struct CaptureEvidenceArgs {
 
 #[derive(Debug, Deserialize)]
 struct RecordFindingArgs {
+    #[serde(default)]
+    id: Option<String>,
     target: String,
     vulnerability: String,
     severity: String,
@@ -113,6 +115,8 @@ struct ReportWriteArgs {
     summary: Option<String>,
     #[serde(default)]
     include_evidence: bool,
+    #[serde(default)]
+    finding_id: Option<String>,
 }
 
 fn default_exec_yield_time_ms() -> u64 {
@@ -439,6 +443,7 @@ impl ToolHandler for RecordFindingHandler {
             .services
             .security_state
             .record_finding(FindingRecord {
+                id: args.id.unwrap_or_default(),
                 target: args.target,
                 vulnerability: args.vulnerability,
                 severity: args.severity,
@@ -475,11 +480,19 @@ impl ToolHandler for ReportWriteHandler {
         } = invocation;
         let arguments = payload_arguments(payload)?;
         let args: ReportWriteArgs = parse_arguments(&arguments)?;
-        let report_path = session
-            .services
-            .security_state
-            .write_report(args.summary.as_deref(), args.include_evidence)
-            .await?;
+        let report_path = if let Some(finding_id) = args.finding_id.as_deref() {
+            session
+                .services
+                .security_state
+                .write_finding_report(finding_id, args.summary.as_deref(), args.include_evidence)
+                .await?
+        } else {
+            session
+                .services
+                .security_state
+                .write_report(args.summary.as_deref(), args.include_evidence)
+                .await?
+        };
         let output = json!({
             "report_path": report_path,
         });

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -819,6 +819,15 @@ fn create_zap_run_tool() -> ToolSpec {
         parameters: JsonSchema::Object {
             properties: BTreeMap::from([
                 (
+                    "id".to_string(),
+                    JsonSchema::String {
+                        description: Some(
+                            "Optional stable finding identifier. Omit to auto-assign."
+                                .to_string(),
+                        ),
+                    },
+                ),
+                (
                     "target".to_string(),
                     JsonSchema::String {
                         description: Some("Absolute in-scope HTTP or HTTPS URL to scan.".to_string()),
@@ -941,6 +950,14 @@ fn create_record_finding_tool() -> ToolSpec {
         parameters: JsonSchema::Object {
             properties: BTreeMap::from([
                 (
+                    "id".to_string(),
+                    JsonSchema::String {
+                        description: Some(
+                            "Optional stable finding identifier. Omit to auto-assign.".to_string(),
+                        ),
+                    },
+                ),
+                (
                     "target".to_string(),
                     JsonSchema::String {
                         description: Some("Affected URL, host, or endpoint.".to_string()),
@@ -1043,6 +1060,15 @@ fn create_report_write_tool() -> ToolSpec {
                     JsonSchema::Boolean {
                         description: Some(
                             "When true, append an evidence section to the report.".to_string(),
+                        ),
+                    },
+                ),
+                (
+                    "finding_id".to_string(),
+                    JsonSchema::String {
+                        description: Some(
+                            "Optional finding id to write a single-finding report artifact."
+                                .to_string(),
                         ),
                     },
                 ),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -275,8 +275,10 @@ pub(crate) use self::agent::spawn_op_forwarder;
 mod session_header;
 use self::session_header::SessionHeader;
 mod provider_selection;
+mod reporting;
 mod skills;
 mod zap_selection;
+use self::reporting::ReportTarget;
 use self::skills::collect_tool_mentions;
 use self::skills::find_app_mentions;
 use self::skills::find_skill_mentions_with_tool_mentions;
@@ -4024,6 +4026,21 @@ impl ChatWidget {
             SlashCommand::Zap => {
                 self.open_zap_popup();
             }
+            SlashCommand::Findings => {
+                let Some(thread_id) = self.thread_id else {
+                    self.add_error_message(
+                        "Findings are unavailable until this session has a thread id.".to_string(),
+                    );
+                    return;
+                };
+                match reporting::findings_summary(&self.config.codex_home, thread_id) {
+                    Ok(summary) => self.add_info_message(summary, None),
+                    Err(err) => self.add_error_message(err),
+                }
+            }
+            SlashCommand::Report => {
+                self.dispatch_command_with_args(SlashCommand::Report, String::new(), Vec::new());
+            }
             SlashCommand::Fast => {
                 let next_tier = if matches!(self.config.service_tier, Some(ServiceTier::Fast)) {
                     None
@@ -4444,6 +4461,34 @@ impl ChatWidget {
                     .send(AppEvent::BeginWindowsSandboxGrantReadRoot {
                         path: prepared_args,
                     });
+                self.bottom_pane.drain_pending_submission_state();
+            }
+            SlashCommand::Report => {
+                let Some(thread_id) = self.thread_id else {
+                    self.add_error_message(
+                        "Reporting is unavailable until this session has a thread id.".to_string(),
+                    );
+                    return;
+                };
+                let target = if trimmed.is_empty() {
+                    Ok(ReportTarget::All)
+                } else {
+                    reporting::parse_report_target(trimmed)
+                };
+                let target = match target {
+                    Ok(target) => target,
+                    Err(err) => {
+                        self.add_error_message(err);
+                        return;
+                    }
+                };
+                match reporting::write_markdown_report(&self.config.codex_home, thread_id, target) {
+                    Ok(path) => self.add_info_message(
+                        format!("Report written to {}", path.display()),
+                        Some("Markdown is currently the only supported format.".to_string()),
+                    ),
+                    Err(err) => self.add_error_message(err),
+                }
                 self.bottom_pane.drain_pending_submission_state();
             }
             _ => self.dispatch_command(cmd),

--- a/codex-rs/tui/src/chatwidget/reporting.rs
+++ b/codex-rs/tui/src/chatwidget/reporting.rs
@@ -1,0 +1,242 @@
+use codex_protocol::ThreadId;
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub(crate) struct PersistedScope {
+    #[serde(default)]
+    mode: String,
+    #[serde(default)]
+    allowed_hosts: Vec<String>,
+    #[serde(default)]
+    allowed_domains: Vec<String>,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PersistedEvidence {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    path: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub(crate) struct PersistedFinding {
+    #[serde(default)]
+    pub(crate) id: String,
+    #[serde(default)]
+    pub(crate) target: String,
+    #[serde(default)]
+    pub(crate) vulnerability: String,
+    #[serde(default)]
+    pub(crate) severity: String,
+    #[serde(default)]
+    pub(crate) confidence: String,
+    #[serde(default)]
+    pub(crate) status: String,
+    #[serde(default)]
+    pub(crate) evidence: Vec<String>,
+    #[serde(default)]
+    pub(crate) reproduction: Option<String>,
+    #[serde(default)]
+    pub(crate) impact: Option<String>,
+    #[serde(default)]
+    pub(crate) limitations: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PersistedSecurityState {
+    #[serde(default)]
+    scope: PersistedScope,
+    #[serde(default)]
+    evidence_index: Vec<PersistedEvidence>,
+    #[serde(default)]
+    findings: Vec<PersistedFinding>,
+}
+
+pub(crate) enum ReportTarget {
+    All,
+    Finding(String),
+}
+
+pub(crate) fn parse_report_target(args: &str) -> Result<ReportTarget, String> {
+    let trimmed = args.trim();
+    if trimmed.is_empty() || trimmed == "all" {
+        return Ok(ReportTarget::All);
+    }
+
+    let parts = trimmed.split_whitespace().collect::<Vec<_>>();
+    if parts.len() == 2 && parts[0] == "finding" {
+        return Ok(ReportTarget::Finding(parts[1].to_string()));
+    }
+
+    Err("Usage: /report [all|finding <id>]".to_string())
+}
+
+pub(crate) fn findings_summary(codex_home: &Path, thread_id: ThreadId) -> Result<String, String> {
+    let state = load_security_state(codex_home, thread_id)?;
+    if state.findings.is_empty() {
+        return Ok("No findings recorded for this session.".to_string());
+    }
+
+    let mut lines = vec![
+        format!("Current findings ({}):", state.findings.len()),
+        String::new(),
+    ];
+    for (index, finding) in state.findings.iter().enumerate() {
+        let id = finding_id(finding, index);
+        lines.push(format!(
+            "- {}: {} on {} [{} / {} / {}]",
+            id,
+            finding.vulnerability,
+            finding.target,
+            finding.severity,
+            finding.confidence,
+            finding.status
+        ));
+    }
+    Ok(lines.join("\n"))
+}
+
+pub(crate) fn write_markdown_report(
+    codex_home: &Path,
+    thread_id: ThreadId,
+    target: ReportTarget,
+) -> Result<PathBuf, String> {
+    let mut state = load_security_state(codex_home, thread_id)?;
+    for (index, finding) in state.findings.iter_mut().enumerate() {
+        if finding.id.trim().is_empty() {
+            finding.id = format!("finding-{:04}", index + 1);
+        }
+    }
+
+    match target {
+        ReportTarget::All => {
+            let report = render_markdown_report(&state);
+            let path = session_root_dir(codex_home, thread_id).join("report.md");
+            fs::write(&path, report).map_err(|err| format!("failed to write report: {err}"))?;
+            Ok(path)
+        }
+        ReportTarget::Finding(id) => {
+            let Some(finding) = state
+                .findings
+                .iter()
+                .find(|finding| finding.id == id)
+                .cloned()
+            else {
+                return Err(format!("Finding `{id}` was not found."));
+            };
+            state.findings = vec![finding];
+            let report = render_markdown_report(&state);
+            let path =
+                session_root_dir(codex_home, thread_id).join(format!("report-finding-{}.md", id));
+            fs::write(&path, report)
+                .map_err(|err| format!("failed to write finding report: {err}"))?;
+            Ok(path)
+        }
+    }
+}
+
+fn load_security_state(
+    codex_home: &Path,
+    thread_id: ThreadId,
+) -> Result<PersistedSecurityState, String> {
+    let root = session_root_dir(codex_home, thread_id);
+    let state_path = root.join("state.json");
+    let findings_path = root.join("findings.json");
+
+    let mut state = read_json::<PersistedSecurityState>(&state_path).unwrap_or_default();
+    let findings = read_json::<Vec<PersistedFinding>>(&findings_path);
+    if let Some(findings) = findings {
+        state.findings = findings;
+    }
+    Ok(state)
+}
+
+fn read_json<T: for<'de> serde::Deserialize<'de>>(path: &Path) -> Option<T> {
+    let bytes = fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn session_root_dir(codex_home: &Path, thread_id: ThreadId) -> PathBuf {
+    codex_home.join("security").join(thread_id.to_string())
+}
+
+fn finding_id(finding: &PersistedFinding, index: usize) -> String {
+    if finding.id.trim().is_empty() {
+        format!("finding-{:04}", index + 1)
+    } else {
+        finding.id.clone()
+    }
+}
+
+fn render_markdown_report(state: &PersistedSecurityState) -> String {
+    let mut lines = vec!["# Security Assessment Report".to_string(), String::new()];
+    lines.push("## Scope".to_string());
+    lines.push(format!(
+        "- Mode: {}",
+        if state.scope.mode.is_empty() {
+            "host_only"
+        } else {
+            state.scope.mode.as_str()
+        }
+    ));
+    if !state.scope.allowed_hosts.is_empty() {
+        lines.push(format!(
+            "- Allowed hosts: {}",
+            state.scope.allowed_hosts.join(", ")
+        ));
+    }
+    if !state.scope.allowed_domains.is_empty() {
+        lines.push(format!(
+            "- Allowed domains: {}",
+            state.scope.allowed_domains.join(", ")
+        ));
+    }
+    if let Some(notes) = state.scope.notes.as_deref() {
+        lines.push(format!("- Notes: {notes}"));
+    }
+    lines.push(String::new());
+    lines.push("## Findings".to_string());
+    if state.findings.is_empty() {
+        lines.push("- No confirmed findings recorded.".to_string());
+    } else {
+        for (index, finding) in state.findings.iter().enumerate() {
+            let id = finding_id(finding, index);
+            lines.push(format!(
+                "- {} on {} [{} / {} / {}] ({id})",
+                finding.vulnerability,
+                finding.target,
+                finding.severity,
+                finding.confidence,
+                finding.status
+            ));
+            if let Some(impact) = finding.impact.as_deref() {
+                lines.push(format!("  Impact: {impact}"));
+            }
+            if let Some(reproduction) = finding.reproduction.as_deref() {
+                lines.push(format!("  Reproduction: {reproduction}"));
+            }
+            if let Some(limitations) = finding.limitations.as_deref() {
+                lines.push(format!("  Limitations: {limitations}"));
+            }
+            if !finding.evidence.is_empty() {
+                lines.push(format!("  Evidence: {}", finding.evidence.join(", ")));
+            }
+        }
+    }
+    lines.push(String::new());
+    lines.push("## Evidence".to_string());
+    if state.evidence_index.is_empty() {
+        lines.push("- No evidence artifacts captured.".to_string());
+    } else {
+        for evidence in &state.evidence_index {
+            lines.push(format!("- {}: {}", evidence.name, evidence.path));
+        }
+    }
+    lines.join("\n")
+}

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__slash_findings_displays_persisted_findings.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__slash_findings_displays_persisted_findings.snap
@@ -1,0 +1,7 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: rendered
+---
+• Current findings (1):
+
+- finding-0001: Reflected XSS on https://example.com [high / confirmed / confirmed]

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -6113,6 +6113,64 @@ async fn slash_rollout_handles_missing_path() {
 }
 
 #[tokio::test]
+async fn slash_findings_displays_persisted_findings() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    let thread_id = ThreadId::default();
+    chat.thread_id = Some(thread_id);
+    let security_dir = chat
+        .config
+        .codex_home
+        .join("security")
+        .join(thread_id.to_string());
+    std::fs::create_dir_all(&security_dir).expect("create security dir");
+    std::fs::write(
+        security_dir.join("findings.json"),
+        r#"[{"id":"finding-0001","target":"https://example.com","vulnerability":"Reflected XSS","severity":"high","confidence":"confirmed","status":"confirmed","evidence":["evidence-1"]}]"#,
+    )
+    .expect("write findings");
+
+    chat.dispatch_command(SlashCommand::Findings);
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected findings summary");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert_snapshot!("slash_findings_displays_persisted_findings", rendered);
+}
+
+#[tokio::test]
+async fn slash_report_finding_writes_markdown_report() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    let thread_id = ThreadId::default();
+    chat.thread_id = Some(thread_id);
+    let security_dir = chat
+        .config
+        .codex_home
+        .join("security")
+        .join(thread_id.to_string());
+    std::fs::create_dir_all(&security_dir).expect("create security dir");
+    std::fs::write(
+        security_dir.join("state.json"),
+        r#"{"scope":{"mode":"host_only","allowed_hosts":["example.com"]},"evidence_index":[{"name":"response","path":"/tmp/response.txt"}],"findings":[{"id":"finding-0001","target":"https://example.com","vulnerability":"Reflected XSS","severity":"high","confidence":"confirmed","status":"confirmed","evidence":["evidence-1"]}]}"#,
+    )
+    .expect("write state");
+
+    chat.dispatch_command_with_args(
+        SlashCommand::Report,
+        "finding finding-0001".to_string(),
+        Vec::new(),
+    );
+
+    let report_path = security_dir.join("report-finding-finding-0001.md");
+    assert!(report_path.exists(), "expected finding report");
+    let report = std::fs::read_to_string(report_path).expect("read report");
+    assert!(report.contains("Reflected XSS"));
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected report success message");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(rendered.contains("Report written to"));
+}
+
+#[tokio::test]
 async fn undo_success_events_render_info_messages() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,6 +17,8 @@ pub enum SlashCommand {
     ApiKey,
     Provider,
     Zap,
+    Findings,
+    Report,
     Fast,
     Approvals,
     Permissions,
@@ -97,6 +99,8 @@ impl SlashCommand {
             SlashCommand::ApiKey => "set or replace the saved API key",
             SlashCommand::Provider => "choose the default provider for future sessions",
             SlashCommand::Zap => "configure the ZAP API used for web scanning",
+            SlashCommand::Findings => "show persisted security findings for this session",
+            SlashCommand::Report => "write markdown reports from persisted security findings",
             SlashCommand::Fast => "toggle Fast mode to enable fastest inference at 2X plan usage",
             SlashCommand::Personality => "choose a communication style for Uxarion",
             SlashCommand::Realtime => "toggle realtime voice mode (experimental)",
@@ -135,6 +139,7 @@ impl SlashCommand {
                 | SlashCommand::ApiKey
                 | SlashCommand::Provider
                 | SlashCommand::Zap
+                | SlashCommand::Report
                 | SlashCommand::Fast
                 | SlashCommand::SandboxReadRoot
         )
@@ -153,6 +158,8 @@ impl SlashCommand {
             | SlashCommand::ApiKey
             | SlashCommand::Provider
             | SlashCommand::Zap
+            | SlashCommand::Findings
+            | SlashCommand::Report
             | SlashCommand::Fast
             | SlashCommand::Personality
             | SlashCommand::Approvals

--- a/docs/project/agent-work/reporting-workflow.md
+++ b/docs/project/agent-work/reporting-workflow.md
@@ -1,0 +1,3 @@
+# Reporting workflow implementation note
+
+- Reporting commands now read persisted security session state under `CODEX_HOME/security/<thread_id>/` to power `/findings`, write session-wide Markdown to `report.md`, and write per-finding Markdown to `report-finding-<id>.md` without introducing a second persistence format.


### PR DESCRIPTION
### Motivation
- Provide a first usable reporting workflow so users can inspect persisted findings and generate Markdown reports from the TUI while reusing existing security-state persistence.
- Ensure findings have stable, human-readable IDs and preserve compatibility with older persisted state that lacks IDs.
- Keep reporting scoped to Markdown artifacts written into the existing `CODEX_HOME/security/<thread_id>/` area without introducing a duplicate persistence format.

### Description
- Add an optional `id` field to `FindingRecord` and implement backfill/auto-assignment with `ensure_finding_ids` and assignment in `record_finding` so legacy persisted findings are supported and new findings receive stable IDs.
- Add per-finding report support via `write_finding_report` and include the finding ID in the rendered Markdown lines; session-wide reports still write to `report.md` and per-finding artifacts write to `report-finding-<id>.md` under the existing session dir.
- Extend tool handler/schema behavior so `record_finding` accepts an optional `id` and `report_write` accepts an optional `finding_id` to request single-finding artifacts, and update the tool spec accordingly (`codex-rs/core/src/tools/spec.rs`, `codex-rs/core/src/tools/handlers/security.rs`).
- Add TUI UX: new slash commands `/findings` and `/report` (with `all` and `finding <id>` parsing) and a dedicated `chatwidget/reporting.rs` module that reads persisted state and performs Markdown writes; tests and an `insta` snapshot were added for the new flows.
- Files changed: `codex-rs/core/src/security/mod.rs`, `codex-rs/core/src/tools/handlers/security.rs`, `codex-rs/core/src/tools/spec.rs`, `codex-rs/tui/src/slash_command.rs`, `codex-rs/tui/src/chatwidget.rs`, `codex-rs/tui/src/chatwidget/reporting.rs`, `codex-rs/tui/src/chatwidget/tests.rs`, `codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__slash_findings_displays_persisted_findings.snap`, and `docs/project/agent-work/reporting-workflow.md`.

### Testing
- Ran `cargo fmt` (succeeded) and `cargo fmt --all` to format sources.
- Attempted `just fmt` (failed because `just` is not installed in this environment and crates.io access is blocked). 
- Ran targeted core tests with `cargo test -p codex-core security_state_ -- --nocapture`, which began execution but the build failed in this environment due to a missing system dependency required by `codex-linux-sandbox` (`libcap` via pkg-config), so the test run could not complete.
- Ran targeted TUI test `cargo test -p codex-tui slash_findings_displays_persisted_findings -- --nocapture`, which could not complete for the same environment build dependency (`libcap`), however the new unit tests and an `insta` snapshot were added in the repo for CI to exercise where system deps are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f5c2f1a08321a09cac50bdac45b6)