### PR TITLE
Add reporting workflow: stable finding IDs, /findings and /report commands, per‑finding Markdown reports

### DIFF
--- a/codex-rs/core/src/security/mod.rs
+++ b/codex-rs/core/src/security/mod.rs
@@ -131,6 +131,8 @@ pub(crate) struct EvidenceRecord {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct FindingRecord {
+    #[serde(default)]
+    pub id: String,
     pub target: String,
     pub vulnerability: String,
     pub severity: String,
@@ -523,7 +525,7 @@ impl SecuritySessionStateService {
 
     pub(crate) async fn record_finding(
         &self,
-        finding: FindingRecord,
+        mut finding: FindingRecord,
     ) -> Result<SecuritySessionState, FunctionCallError> {
         if !self.enabled {
             return Err(FunctionCallError::RespondToModel(
@@ -532,6 +534,9 @@ impl SecuritySessionStateService {
         }
 
         let mut state = self.state.lock().await;
+        if finding.id.trim().is_empty() {
+            finding.id = next_finding_id(&state.findings);
+        }
         state.findings.push(finding);
         let snapshot = state.clone();
         drop(state);
@@ -565,6 +570,7 @@ impl SecuritySessionStateService {
         &self,
         summary: Option<&str>,
         include_evidence: bool,
+        finding_id: Option<&str>,
     ) -> Result<PathBuf, FunctionCallError> {
         if !self.enabled {
             return Err(FunctionCallError::RespondToModel(
@@ -580,6 +586,40 @@ impl SecuritySessionStateService {
                 &b.severity,
             ))
         });
+
+        if let Some(finding_id) = finding_id {
+            let finding_id = finding_id.trim();
+            if finding_id.is_empty() {
+                return Err(FunctionCallError::RespondToModel(
+                    "`finding_id` must not be empty".to_string(),
+                ));
+            }
+
+            let selected = snapshot
+                .findings
+                .iter()
+                .find(|finding| finding.id == finding_id)
+                .cloned()
+                .ok_or_else(|| {
+                    FunctionCallError::RespondToModel(format!(
+                        "finding `{finding_id}` was not found"
+                    ))
+                })?;
+
+            snapshot.findings = vec![selected];
+            let report = render_report_markdown(&snapshot, summary, include_evidence);
+            let report_path = self.root_dir.join(format!(
+                "report-finding-{}.md",
+                sanitize_identifier(finding_id)
+            ));
+            fs::write(&report_path, report).await.map_err(|err| {
+                FunctionCallError::RespondToModel(format!(
+                    "failed to write finding report for `{finding_id}`: {err}"
+                ))
+            })?;
+            return Ok(report_path);
+        }
+
         let report = render_report_markdown(&snapshot, summary, include_evidence);
         fs::write(&self.report_path, report).await.map_err(|err| {
             FunctionCallError::RespondToModel(format!("failed to write security report: {err}"))
@@ -810,7 +850,27 @@ async fn load_state_from_disk(
     {
         state.findings = findings;
     }
+    ensure_finding_ids(&mut state.findings);
     Some(state)
+}
+
+fn next_finding_id(findings: &[FindingRecord]) -> String {
+    let mut next = 1usize;
+    while findings
+        .iter()
+        .any(|finding| finding.id == format!("finding-{next:04}"))
+    {
+        next += 1;
+    }
+    format!("finding-{next:04}")
+}
+
+fn ensure_finding_ids(findings: &mut [FindingRecord]) {
+    for index in 0..findings.len() {
+        if findings[index].id.trim().is_empty() {
+            findings[index].id = next_finding_id(&findings[..index]);
+        }
+    }
 }
 
 fn message_text(content: &[ContentItem]) -> String {
@@ -1101,7 +1161,8 @@ fn render_report_markdown(
     } else {
         for finding in &state.findings {
             lines.push(format!(
-                "- {} on {} [{} / {} / {}]",
+                "- [{}] {} on {} [{} / {} / {}]",
+                finding.id,
                 finding.vulnerability,
                 finding.target,
                 finding.severity,
@@ -1201,6 +1262,7 @@ mod tests {
             .expect("scope");
         service
             .record_finding(FindingRecord {
+                id: String::new(),
                 target: "https://example.com".to_string(),
                 vulnerability: "Reflected XSS".to_string(),
                 severity: "high".to_string(),
@@ -1215,11 +1277,12 @@ mod tests {
             .expect("finding");
 
         let report = service
-            .write_report(Some("Automated security assessment"), true)
+            .write_report(Some("Automated security assessment"), true, None)
             .await
             .expect("report");
         let report_contents = std::fs::read_to_string(report).expect("read report");
         assert!(report_contents.contains("Reflected XSS"));
+        assert!(report_contents.contains("[finding-0001]"));
 
         let state_contents = std::fs::read_to_string(&service.state_path).expect("read state");
         assert!(state_contents.contains("Reflected XSS"));
@@ -1276,6 +1339,93 @@ mod tests {
         let snapshot = service.snapshot().await;
         assert_eq!(snapshot.commands.len(), 1);
         assert_eq!(snapshot.commands[0].cmd, "nmap -p- 127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn load_state_assigns_ids_to_legacy_findings_without_ids() {
+        let tmp = tempdir().expect("tempdir");
+        let thread_id = ThreadId::new();
+        let root = tmp.path().join("security").join(thread_id.to_string());
+        std::fs::create_dir_all(&root).expect("root");
+
+        let legacy_findings = serde_json::json!([
+            {
+                "target": "https://example.com",
+                "vulnerability": "Reflected XSS",
+                "severity": "high",
+                "confidence": "confirmed",
+                "evidence": ["ev-1"],
+                "status": "confirmed"
+            }
+        ]);
+        std::fs::write(
+            root.join("findings.json"),
+            serde_json::to_vec_pretty(&legacy_findings).expect("serialize findings"),
+        )
+        .expect("write legacy findings");
+
+        let service = SecuritySessionStateService::new(
+            tmp.path(),
+            &thread_id,
+            true,
+            SecurityZapConfig::default(),
+        )
+        .await;
+
+        let snapshot = service.snapshot().await;
+        assert_eq!(snapshot.findings.len(), 1);
+        assert_eq!(snapshot.findings[0].id, "finding-0001");
+    }
+
+    #[tokio::test]
+    async fn write_report_for_single_finding_creates_finding_artifact() {
+        let tmp = tempdir().expect("tempdir");
+        let service = SecuritySessionStateService::new(
+            tmp.path(),
+            &ThreadId::default(),
+            true,
+            SecurityZapConfig::default(),
+        )
+        .await;
+        service
+            .record_finding(FindingRecord {
+                id: String::new(),
+                target: "https://example.com".to_string(),
+                vulnerability: "Reflected XSS".to_string(),
+                severity: "high".to_string(),
+                confidence: "confirmed".to_string(),
+                evidence: vec!["ev-1".to_string()],
+                reproduction: None,
+                impact: None,
+                limitations: None,
+                status: "confirmed".to_string(),
+            })
+            .await
+            .expect("first finding");
+        service
+            .record_finding(FindingRecord {
+                id: String::new(),
+                target: "https://example.org".to_string(),
+                vulnerability: "SQL Injection".to_string(),
+                severity: "critical".to_string(),
+                confidence: "confirmed".to_string(),
+                evidence: vec!["ev-2".to_string()],
+                reproduction: None,
+                impact: None,
+                limitations: None,
+                status: "confirmed".to_string(),
+            })
+            .await
+            .expect("second finding");
+
+        let finding_report = service
+            .write_report(None, false, Some("finding-0002"))
+            .await
+            .expect("finding report");
+
+        let contents = std::fs::read_to_string(&finding_report).expect("read finding report");
+        assert!(contents.contains("[finding-0002]"));
+        assert!(!contents.contains("[finding-0001]"));
     }
 
     #[test]

--- a/codex-rs/core/src/tools/handlers/security.rs
+++ b/codex-rs/core/src/tools/handlers/security.rs
@@ -113,6 +113,8 @@ struct ReportWriteArgs {
     summary: Option<String>,
     #[serde(default)]
     include_evidence: bool,
+    #[serde(default)]
+    finding_id: Option<String>,
 }
 
 fn default_exec_yield_time_ms() -> u64 {
@@ -439,6 +441,7 @@ impl ToolHandler for RecordFindingHandler {
             .services
             .security_state
             .record_finding(FindingRecord {
+                id: String::new(),
                 target: args.target,
                 vulnerability: args.vulnerability,
                 severity: args.severity,
@@ -478,7 +481,11 @@ impl ToolHandler for ReportWriteHandler {
         let report_path = session
             .services
             .security_state
-            .write_report(args.summary.as_deref(), args.include_evidence)
+            .write_report(
+                args.summary.as_deref(),
+                args.include_evidence,
+                args.finding_id.as_deref(),
+            )
             .await?;
         let output = json!({
             "report_path": report_path,

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -1046,6 +1046,15 @@ fn create_report_write_tool() -> ToolSpec {
                         ),
                     },
                 ),
+                (
+                    "finding_id".to_string(),
+                    JsonSchema::String {
+                        description: Some(
+                            "Optional finding ID to render a single-finding report artifact."
+                                .to_string(),
+                        ),
+                    },
+                ),
             ]),
             required: None,
             additional_properties: Some(false.into()),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -275,8 +275,10 @@ pub(crate) use self::agent::spawn_op_forwarder;
 mod session_header;
 use self::session_header::SessionHeader;
 mod provider_selection;
+mod reporting;
 mod skills;
 mod zap_selection;
+use self::reporting::ReportScope;
 use self::skills::collect_tool_mentions;
 use self::skills::find_app_mentions;
 use self::skills::find_skill_mentions_with_tool_mentions;
@@ -4214,6 +4216,12 @@ impl ChatWidget {
             SlashCommand::DebugConfig => {
                 self.add_debug_config_output();
             }
+            SlashCommand::Findings => {
+                self.show_security_findings();
+            }
+            SlashCommand::Report => {
+                self.run_report_command(ReportScope::All);
+            }
             SlashCommand::Statusline => {
                 self.open_status_line_setup();
             }
@@ -4446,8 +4454,45 @@ impl ChatWidget {
                     });
                 self.bottom_pane.drain_pending_submission_state();
             }
+            SlashCommand::Report if !trimmed.is_empty() => {
+                let Some((prepared_args, _prepared_elements)) =
+                    self.bottom_pane.prepare_inline_args_submission(false)
+                else {
+                    return;
+                };
+                match reporting::parse_report_scope(prepared_args.as_str()) {
+                    Ok(scope) => self.run_report_command(scope),
+                    Err(message) => self.add_error_message(message),
+                }
+                self.bottom_pane.drain_pending_submission_state();
+            }
             _ => self.dispatch_command(cmd),
         }
+    }
+
+    fn show_security_findings(&mut self) {
+        match reporting::load_findings(&self.config.codex_home, self.thread_id) {
+            Ok(findings) => {
+                let message = reporting::format_findings_summary(&findings);
+                let hint = if findings.is_empty() {
+                    Some(
+                        "Record findings during the session, then run /findings again.".to_string(),
+                    )
+                } else {
+                    Some(
+                        "Run /report or /report finding <id> to generate Markdown artifacts."
+                            .to_string(),
+                    )
+                };
+                self.add_info_message(message, hint);
+            }
+            Err(err) => self.add_error_message(err),
+        }
+    }
+
+    fn run_report_command(&mut self, scope: ReportScope<'_>) {
+        let prompt = reporting::report_prompt(scope);
+        self.submit_user_message(prompt.into());
     }
 
     fn show_rename_prompt(&mut self) {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4471,6 +4471,12 @@ impl ChatWidget {
     }
 
     fn show_security_findings(&mut self) {
+        if self.thread_id.is_none() {
+            self.add_error_message(
+                "Findings are unavailable until this session has a thread id.".to_string(),
+            );
+            return;
+        }
         match reporting::load_findings(&self.config.codex_home, self.thread_id) {
             Ok(findings) => {
                 let message = reporting::format_findings_summary(&findings);

--- a/codex-rs/tui/src/chatwidget/reporting.rs
+++ b/codex-rs/tui/src/chatwidget/reporting.rs
@@ -1,0 +1,113 @@
+use codex_protocol::ThreadId;
+use serde::Deserialize;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReportScope<'a> {
+    All,
+    Finding(&'a str),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct PersistedFinding {
+    #[serde(default)]
+    pub id: String,
+    pub target: String,
+    pub vulnerability: String,
+    pub severity: String,
+    pub confidence: String,
+    pub status: String,
+}
+
+pub(super) fn parse_report_scope(args: &str) -> Result<ReportScope<'_>, String> {
+    let trimmed = args.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("all") {
+        return Ok(ReportScope::All);
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    let command = parts.next();
+    let maybe_id = parts.next();
+    let extra = parts.next();
+
+    if matches!(command, Some(value) if value.eq_ignore_ascii_case("finding"))
+        && let Some(id) = maybe_id
+        && extra.is_none()
+    {
+        return Ok(ReportScope::Finding(id));
+    }
+
+    Err("Usage: /report [all|finding <id>]".to_string())
+}
+
+pub(super) fn security_session_dir(
+    codex_home: &Path,
+    thread_id: Option<ThreadId>,
+) -> Option<PathBuf> {
+    thread_id.map(|id| codex_home.join("security").join(id.to_string()))
+}
+
+pub(super) fn load_findings(
+    codex_home: &Path,
+    thread_id: Option<ThreadId>,
+) -> Result<Vec<PersistedFinding>, String> {
+    let Some(session_dir) = security_session_dir(codex_home, thread_id) else {
+        return Ok(Vec::new());
+    };
+
+    let findings_path = session_dir.join("findings.json");
+    if !findings_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let bytes = std::fs::read(&findings_path).map_err(|err| {
+        format!(
+            "Failed to read findings from {}: {err}",
+            findings_path.display()
+        )
+    })?;
+    let mut findings: Vec<PersistedFinding> = serde_json::from_slice(&bytes).map_err(|err| {
+        format!(
+            "Failed to parse findings from {}: {err}",
+            findings_path.display()
+        )
+    })?;
+
+    for index in 0..findings.len() {
+        if findings[index].id.trim().is_empty() {
+            findings[index].id = format!("finding-{:04}", index + 1);
+        }
+    }
+
+    Ok(findings)
+}
+
+pub(super) fn format_findings_summary(findings: &[PersistedFinding]) -> String {
+    if findings.is_empty() {
+        return "No findings have been recorded yet.".to_string();
+    }
+
+    let mut lines = vec![format!("{} finding(s):", findings.len())];
+    for finding in findings {
+        lines.push(format!(
+            "- [{}] {} on {} [{} / {} / {}]",
+            finding.id,
+            finding.vulnerability,
+            finding.target,
+            finding.severity,
+            finding.confidence,
+            finding.status
+        ));
+    }
+    lines.join("\n")
+}
+
+pub(super) fn report_prompt(scope: ReportScope<'_>) -> String {
+    match scope {
+        ReportScope::All => "Write a Markdown security report now by calling `report_write` with `include_evidence=true` and no `finding_id`. After writing the file, tell me the exact `report_path`.".to_string(),
+        ReportScope::Finding(id) => format!(
+            "Write a Markdown report for finding `{id}` now by calling `report_write` with `include_evidence=true` and `finding_id` set to `{id}`. After writing the file, tell me the exact `report_path`."
+        ),
+    }
+}

--- a/codex-rs/tui/src/chatwidget/reporting.rs
+++ b/codex-rs/tui/src/chatwidget/reporting.rs
@@ -13,10 +13,15 @@ pub(super) enum ReportScope<'a> {
 pub(super) struct PersistedFinding {
     #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub target: String,
+    #[serde(default)]
     pub vulnerability: String,
+    #[serde(default)]
     pub severity: String,
+    #[serde(default)]
     pub confidence: String,
+    #[serde(default)]
     pub status: String,
 }
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__findings_summary_text.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__findings_summary_text.snap
@@ -1,0 +1,7 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: "super::reporting::format_findings_summary(&findings)"
+---
+2 finding(s):
+- [finding-0001] Reflected XSS on https://example.com [high / confirmed / confirmed]
+- [finding-0002] SQL Injection on https://example.org [critical / confirmed / confirmed]

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -6172,6 +6172,21 @@ async fn slash_findings_renders_current_findings_summary() {
 }
 
 #[tokio::test]
+async fn slash_findings_requires_thread_id() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.dispatch_command(SlashCommand::Findings);
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected one error message");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("Findings are unavailable until this session has a thread id."),
+        "expected missing-thread guidance, got {rendered:?}"
+    );
+}
+
+#[tokio::test]
 async fn slash_report_with_finding_id_submits_user_turn() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
     chat.thread_id = Some(ThreadId::new());

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -2016,6 +2016,13 @@ fn lines_to_single_string(lines: &[ratatui::text::Line<'static>]) -> String {
     s
 }
 
+fn user_input_text(input: UserInput) -> String {
+    match input {
+        UserInput::Text { text, .. } => text,
+        _ => panic!("expected text input"),
+    }
+}
+
 #[tokio::test]
 async fn collab_spawn_end_shows_requested_model_and_effort() {
     let (mut chat, mut rx, _ops) = make_chatwidget_manual(None).await;
@@ -6109,6 +6116,122 @@ async fn slash_rollout_handles_missing_path() {
     assert!(
         rendered.contains("not available"),
         "expected missing rollout path message: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn slash_findings_renders_current_findings_summary() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    let codex_home = tempdir().expect("tempdir");
+    let thread_id = ThreadId::new();
+    chat.config.codex_home = codex_home.path().to_path_buf();
+    chat.thread_id = Some(thread_id);
+
+    let security_dir = chat
+        .config
+        .codex_home
+        .join("security")
+        .join(thread_id.to_string());
+    std::fs::create_dir_all(&security_dir).expect("security dir");
+    let findings = serde_json::json!([
+        {
+            "id": "finding-0001",
+            "target": "https://example.com",
+            "vulnerability": "Reflected XSS",
+            "severity": "high",
+            "confidence": "confirmed",
+            "status": "confirmed"
+        },
+        {
+            "target": "https://example.org",
+            "vulnerability": "SQL Injection",
+            "severity": "critical",
+            "confidence": "confirmed",
+            "status": "confirmed"
+        }
+    ]);
+    std::fs::write(
+        security_dir.join("findings.json"),
+        serde_json::to_vec_pretty(&findings).expect("serialize findings"),
+    )
+    .expect("write findings");
+
+    chat.dispatch_command(SlashCommand::Findings);
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected a findings summary info message");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("[finding-0001] Reflected XSS on https://example.com"),
+        "expected first finding in summary, got {rendered:?}"
+    );
+    assert!(
+        rendered.contains("[finding-0002] SQL Injection on https://example.org"),
+        "expected legacy finding id fallback in summary, got {rendered:?}"
+    );
+}
+
+#[tokio::test]
+async fn slash_report_with_finding_id_submits_user_turn() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
+    chat.thread_id = Some(ThreadId::new());
+
+    chat.dispatch_command_with_args(
+        SlashCommand::Report,
+        "finding finding-0001".to_string(),
+        Vec::new(),
+    );
+
+    match next_submit_op(&mut op_rx) {
+        Op::UserTurn { input, .. } => {
+            let text = user_input_text(input);
+            assert!(
+                text.contains("finding `finding-0001`"),
+                "expected report prompt to include finding id, got {text:?}"
+            );
+        }
+        other => panic!("expected /report to submit a user turn, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn slash_report_rejects_invalid_args() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.dispatch_command_with_args(SlashCommand::Report, "finding".to_string(), Vec::new());
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected one usage error message");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("Usage: /report [all|finding <id>]"),
+        "expected usage guidance, got {rendered:?}"
+    );
+}
+
+#[test]
+fn findings_summary_text_snapshot() {
+    let findings = vec![
+        super::reporting::PersistedFinding {
+            id: "finding-0001".to_string(),
+            target: "https://example.com".to_string(),
+            vulnerability: "Reflected XSS".to_string(),
+            severity: "high".to_string(),
+            confidence: "confirmed".to_string(),
+            status: "confirmed".to_string(),
+        },
+        super::reporting::PersistedFinding {
+            id: "finding-0002".to_string(),
+            target: "https://example.org".to_string(),
+            vulnerability: "SQL Injection".to_string(),
+            severity: "critical".to_string(),
+            confidence: "confirmed".to_string(),
+            status: "confirmed".to_string(),
+        },
+    ];
+    assert_snapshot!(
+        "findings_summary_text",
+        super::reporting::format_findings_summary(&findings)
     );
 }
 

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -42,6 +42,8 @@ pub enum SlashCommand {
     Mention,
     Status,
     DebugConfig,
+    Findings,
+    Report,
     Statusline,
     Theme,
     Mcp,
@@ -87,6 +89,8 @@ impl SlashCommand {
             SlashCommand::Skills => "use skills to improve how Uxarion performs specific tasks",
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::DebugConfig => "show config layers and requirement sources for debugging",
+            SlashCommand::Findings => "show current security findings",
+            SlashCommand::Report => "write a markdown security report",
             SlashCommand::Statusline => "configure which items appear in the status line",
             SlashCommand::Theme => "choose a syntax highlighting theme",
             SlashCommand::Ps => "list background terminals",
@@ -137,6 +141,7 @@ impl SlashCommand {
                 | SlashCommand::Zap
                 | SlashCommand::Fast
                 | SlashCommand::SandboxReadRoot
+                | SlashCommand::Report
         )
     }
 
@@ -173,6 +178,8 @@ impl SlashCommand {
             | SlashCommand::Skills
             | SlashCommand::Status
             | SlashCommand::DebugConfig
+            | SlashCommand::Findings
+            | SlashCommand::Report
             | SlashCommand::Ps
             | SlashCommand::Clean
             | SlashCommand::Mcp

--- a/docs/project/agent-work/reporting-workflow.md
+++ b/docs/project/agent-work/reporting-workflow.md
@@ -1,0 +1,3 @@
+# Reporting Workflow Implementation Note
+
+- Added stable `finding-*` IDs in persisted security findings (including backfill for legacy findings without IDs), plus TUI `/findings` and `/report` slash-command flows that read existing session state and trigger Markdown report generation (`/report`, `/report all`, `/report finding <id>`) through the existing `report_write` tool path.


### PR DESCRIPTION
### Motivation
- Provide a first usable reporting workflow so users can inspect findings and generate Markdown reports from the TUI without changing the existing security system design. 
- Ensure findings are referenceable by introducing stable IDs while preserving compatibility with older persisted state that lacks IDs.

### Description
- Persisted finding IDs: introduce `FindingRecord.id` with automatic assignment for new findings and backfill for legacy findings on load; add `next_finding_id` and `ensure_finding_ids` helpers. (changed `codex-rs/core/src/security/mod.rs`).
- Report writer: extend `write_report` to accept an optional `finding_id` and produce either the session-wide `report.md` or a per-finding `report-finding-<id>.md` artifact under the existing session security directory. (changed `codex-rs/core/src/security/mod.rs`).
- Tool and handler plumbing: add `finding_id` param to the `report_write` tool spec and handler so existing tool path can trigger per-finding reports. (changed `codex-rs/core/src/tools/spec.rs` and `codex-rs/core/src/tools/handlers/security.rs`).
- TUI integration: add `/findings` and `/report` (with `all` and `finding <id>` parsing) to the slash-command registry and dispatch flow, implement a new `chatwidget/reporting.rs` module to parse args, load persisted findings, render brief summaries, and construct report prompts; wire new commands into `chatwidget.rs`. (added `codex-rs/tui/src/chatwidget/reporting.rs`; changed `codex-rs/tui/src/slash_command.rs` and `codex-rs/tui/src/chatwidget.rs`).
- Tests and snapshots: add core tests for ID backfill and single-finding report artifact and TUI tests for `/findings` and `/report` behaviors, plus an `insta` snapshot for findings summary text. (changed `codex-rs/core/src/security/mod.rs` tests; changed `codex-rs/tui/src/chatwidget/tests.rs`; added snapshot `codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__findings_summary_text.snap`).
- Documentation: add one implementation note at `docs/project/agent-work/reporting-workflow.md` describing the change.

### Testing
- Ran formatting: `cargo fmt -- --config imports_granularity=Item` succeeded (local rustfmt warnings about unstable option were produced but formatting completed).
- Attempted `just fmt` (as requested) failed because `just` is not available in the environment, and installing it failed due to blocked crates.io network access. 
- Ran targeted core tests: `cargo test -p codex-core security_state_persists_findings_and_report` started but the build failed in this environment due to the platform needing system `libcap.pc` for `codex-linux-sandbox` (native dependency missing), so the test could not complete.
- Ran targeted TUI tests: `cargo test -p codex-tui slash_findings_renders_current_findings_summary` was attempted but the same build environment issue (missing `libcap.pc` when compiling workspace crates) prevented the test from completing.
- Snapshot: added `codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__findings_summary_text.snap`; CI should validate/accept this snapshot when run in a full environment.

Files changed (high level)
- codex-rs/core/src/security/mod.rs
- codex-rs/core/src/tools/handlers/security.rs
- codex-rs/core/src/tools/spec.rs
- codex-rs/tui/src/slash_command.rs
- codex-rs/tui/src/chatwidget.rs
- codex-rs/tui/src/chatwidget/reporting.rs (new)
- codex-rs/tui/src/chatwidget/tests.rs
- codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__findings_summary_text.snap (new)
- docs/project/agent-work/reporting-workflow.md (new)

Notes
- The implementation strictly reuses the existing security state service and the `report_write` tool path; no ZAP, provider-selection, or updater subsystems were modified.
- Local runner limitations prevented `just fmt` and full test execution; CI (or a dev machine with `libcap` installed) should be used to run the full suite and accept snapshots if intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f5c2f1a08321a09cac50bdac45b6)