### PR TITLE
Add public demo pack for Uxarion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Uxarion public demo pack
+
+This folder contains the material needed to turn Uxarion from a private technical project into a public product demo.
+
+## Start here
+
+1. Read [`product-gap-review.md`](./product-gap-review.md).
+2. Record the short demo using [`demos/crapi-90-second-demo.md`](./demos/crapi-90-second-demo.md).
+3. Record the longer walkthrough using [`demos/technical-deep-dive-demo.md`](./demos/technical-deep-dive-demo.md).
+4. Prepare the screenshots, sample report, and tutorial using [`demo-assets-checklist.md`](./demo-assets-checklist.md).
+5. Post using [`social-launch-pack.md`](./social-launch-pack.md).
+
+## Message to keep consistent
+
+> Uxarion is a local-first AI security agent for authorized web testing: scoped assessment, saved evidence, recorded findings, and generated reports.
+
+## What matters
+
+Do not sell the idea. Show the proof.
+
+The public package should prove:
+
+- Uxarion binds itself to declared target scope.
+- Uxarion can test an authorized local lab.
+- Uxarion can save evidence.
+- Uxarion can record findings.
+- Uxarion can generate a useful report.
+
+## What to publish first
+
+Publish the 90-second crAPI video first. Then send the long technical demo to people who ask how it works.
+
+## Safety boundary
+
+All public demos should use local labs, owned apps, internal targets, or explicitly authorized bug bounty scope. Do not demo against random public targets.

--- a/docs/demo-assets-checklist.md
+++ b/docs/demo-assets-checklist.md
@@ -1,0 +1,122 @@
+# Demo assets checklist
+
+This checklist exists because a good product demo is not just a screen recording. It is a sales asset.
+
+## Minimum assets before posting publicly
+
+### 1. Short video
+
+- Length: 60-90 seconds.
+- Format: vertical and horizontal if possible.
+- Hook in first 3 seconds.
+- Show Uxarion, target scope, evidence, and report.
+- Hide all keys, cookies, tokens, personal paths, and private accounts.
+
+### 2. Long video
+
+- Length: 5-7 minutes.
+- Format: horizontal.
+- Includes setup, scope, workflow, evidence, report, limitations.
+- Has chapters.
+- Uploaded somewhere linkable.
+
+### 3. Screenshots
+
+Create these exact screenshots:
+
+1. Uxarion terminal after launch.
+2. Scope prompt with `http://127.0.0.1:8888`.
+3. Confirmed finding summary.
+4. Evidence artifact saved.
+5. Generated report.
+6. README top section with install command.
+
+### 4. Sample report
+
+Add a sanitized sample report folder.
+
+Recommended path:
+
+```text
+examples/crapi-sample-report/report.md
+```
+
+The report should contain:
+
+- assessment scope,
+- target,
+- methodology,
+- findings table,
+- one detailed finding,
+- evidence references,
+- reproduction status,
+- limitations,
+- remediation guidance.
+
+### 5. README proof section
+
+Add this near the top of the README:
+
+```md
+## Demo result
+
+| Target | Result | Output |
+| --- | --- | --- |
+| OWASP crAPI local lab | 4 confirmed authorization/state bugs | Saved evidence + generated Markdown report |
+```
+
+### 6. Repro tutorial
+
+Add a tutorial called:
+
+```text
+docs/demos/crapi-repro-tutorial.md
+```
+
+It should walk a user from local lab startup to generated report.
+
+### 7. Feedback issue template
+
+Create a GitHub issue template for demo feedback:
+
+```text
+What OS are you using?
+How did you install Uxarion?
+What target/lab did you test?
+Where did setup break?
+Did evidence/report generation work?
+What was unclear?
+```
+
+## Quality bar
+
+Do not post until these are true:
+
+- A stranger can tell what Uxarion does in 10 seconds.
+- A stranger can install it without asking you.
+- A stranger can reproduce at least one local-lab result.
+- A stranger can see a real generated report.
+- The safety boundary is obvious.
+
+## Do not publish with these problems
+
+- README only says abstract AI/security words.
+- Demo is longer than 2 minutes with no clear hook.
+- No sample output.
+- No report screenshot.
+- No clear target scope.
+- No install status for Windows/macOS/Linux.
+- No explanation of authorized use.
+
+## The best first public demo package
+
+```text
+README proof table
++ 90-second video
++ 5-minute technical video
++ sample report
++ crAPI tutorial
++ social launch pack
+```
+
+Anything less is weaker than it should be.

--- a/docs/demos/crapi-90-second-demo.md
+++ b/docs/demos/crapi-90-second-demo.md
@@ -1,0 +1,212 @@
+# crAPI 90-second public demo script
+
+## Goal
+
+Make strangers understand Uxarion fast.
+
+The demo is not about showing every command. The demo is about proving this:
+
+> Uxarion can take an authorized local web target, test it like a security agent, save evidence, and produce a usable report.
+
+Use OWASP crAPI only. Do not aim this demo at a real public target.
+
+## Recording setup
+
+Use a clean terminal with a large font. Hide API keys, tokens, local usernames, and private paths.
+
+Recommended layout:
+
+- left: terminal running Uxarion,
+- right: browser showing crAPI,
+- small bottom/right: generated report or evidence folder near the end.
+
+Required local services:
+
+```text
+crAPI:   http://127.0.0.1:8888
+MailHog: http://127.0.0.1:8025
+ZAP:     optional, only if configured cleanly
+```
+
+## Demo title
+
+Use this exact title on the thumbnail or first screen:
+
+```text
+I gave an AI security agent a vulnerable app.
+It found 4 real bugs and wrote the report.
+```
+
+## Timeline
+
+### 0-5s: hook
+
+On screen:
+
+```text
+Most AI coding agents can poke at an app.
+Uxarion is built to test authorized targets and save evidence.
+```
+
+Voiceover:
+
+```text
+I built Uxarion, a local-first AI security agent. In this demo, I point it at OWASP crAPI, a deliberately vulnerable app, and make it produce evidence and a report.
+```
+
+### 5-15s: scope
+
+Show the target and say:
+
+```text
+Target: http://127.0.0.1:8888
+Scope: local lab only
+MailHog: http://127.0.0.1:8025
+```
+
+Voiceover:
+
+```text
+This is an authorized local lab. Uxarion binds the session to the target scope before testing.
+```
+
+### 15-25s: launch Uxarion
+
+Show:
+
+```bash
+uxarion
+```
+
+Then prompt Uxarion:
+
+```text
+Assess http://127.0.0.1:8888 as an authorized local OWASP crAPI lab. Focus on authorization and state bugs. Save evidence for confirmed findings and write a final report.
+```
+
+Voiceover:
+
+```text
+The important part is not just scanning. I ask it to focus on authorization and state bugs, save evidence, and write a report.
+```
+
+### 25-50s: discovery and confirmation
+
+Show fast cuts of Uxarion:
+
+- inspecting routes,
+- comparing behavior between two accounts,
+- replaying a request,
+- confirming a BOLA/IDOR-style issue,
+- saving evidence.
+
+On screen text:
+
+```text
+Confirmed: user can access or act on another user's data
+Evidence: request + response saved
+```
+
+Voiceover:
+
+```text
+Here it compares accounts and confirms that one user can access or act on another user's data. The point is not a flashy exploit. The point is confirmed evidence.
+```
+
+### 50-70s: findings
+
+Show a terminal/report view with a compact summary.
+
+On screen:
+
+```text
+Findings found: 4
+Type: authorization / state issues
+Evidence: saved
+Report: generated
+```
+
+Voiceover:
+
+```text
+In this run, Uxarion found four real issues in the vulnerable app, including BOLA-style authorization problems.
+```
+
+### 70-85s: report
+
+Show `report.md` or the generated report preview.
+
+On screen:
+
+```text
+Each finding includes:
+- target
+- severity
+- confidence
+- evidence
+- reproduction status
+- impact
+- limitations
+```
+
+Voiceover:
+
+```text
+It does not just say 'vulnerable.' It writes a report from saved artifacts: target, severity, confidence, reproduction status, impact, limitations, and evidence.
+```
+
+### 85-90s: CTA
+
+On screen:
+
+```text
+Open source: github.com/rachidlaad/uxarion
+Install: npm install -g uxarion
+```
+
+Voiceover:
+
+```text
+The repo is open source. Try it on a local lab or your own authorized target.
+```
+
+## What to cut
+
+Cut anything that does not prove the promise.
+
+Remove:
+
+- long installation time,
+- model thinking pauses,
+- irrelevant terminal scrolling,
+- private paths,
+- failed setup attempts,
+- raw tokens or cookies,
+- long exploit details that make the demo look irresponsible.
+
+## What to show clearly
+
+Keep these shots:
+
+1. target URL and scope,
+2. Uxarion prompt,
+3. account comparison or request replay,
+4. evidence being saved,
+5. final report,
+6. install command and GitHub link.
+
+## Short caption
+
+```text
+I built Uxarion: a local-first AI security agent for authorized web testing.
+
+In this demo it tests OWASP crAPI, confirms 4 authorization/state bugs, saves request/response evidence, and generates a pentest-style report.
+
+Open source: github.com/rachidlaad/uxarion
+```
+
+## Brutal quality bar
+
+If a stranger watches this and still asks "what does it do?", the demo failed.
+
+If a stranger watches this and says "okay, I want to try it on crAPI," the demo worked.

--- a/docs/demos/technical-deep-dive-demo.md
+++ b/docs/demos/technical-deep-dive-demo.md
@@ -1,0 +1,187 @@
+# Technical deep-dive demo script
+
+## Goal
+
+This is the 5-7 minute demo for developers, security students, and bug bounty beginners who want to see how Uxarion actually works.
+
+The 90-second demo sells attention. This deep dive converts attention into trust.
+
+## Main promise
+
+```text
+Uxarion is not just a chat wrapper.
+It runs a scoped security workflow, uses security tools, records evidence, stores findings, and writes a report.
+```
+
+## Demo structure
+
+### 1. Start with the problem
+
+Say:
+
+```text
+Normal AI coding agents are dangerous for security work because they blur scope, mix coding and testing, and often leave the result as chat text. Uxarion is built around scoped, operator-driven security assessment.
+```
+
+Show the README install command:
+
+```bash
+npm install -g uxarion
+```
+
+Then launch:
+
+```bash
+uxarion
+```
+
+### 2. Show target scope
+
+Use only a local vulnerable app:
+
+```text
+Target: http://127.0.0.1:8888
+Scope: OWASP crAPI local lab only
+```
+
+Ask:
+
+```text
+Set the scope to http://127.0.0.1:8888 only. Assess this authorized local crAPI lab for authorization and state-management issues. Prefer passive inspection first, then bounded verification. Save evidence for confirmed findings and generate a final report.
+```
+
+Explain:
+
+```text
+The exact target matters. A security agent should not wander from a local lab to the internet or a different host.
+```
+
+### 3. Show the workflow loop
+
+Show Uxarion performing these steps:
+
+1. inspect pages and API behavior,
+2. identify account-specific endpoints,
+3. compare behavior across users,
+4. replay a bounded request,
+5. mark the result as confirmed, inconclusive, or not reproduced,
+6. save evidence,
+7. record a finding.
+
+Say:
+
+```text
+The workflow is not magic. It is careful comparison, request inspection, evidence, and reporting.
+```
+
+### 4. Show evidence, not just claims
+
+Open the saved evidence artifact or show the terminal output pointing to it.
+
+Say:
+
+```text
+A finding without evidence is just a guess. Uxarion saves artifacts so the report can be checked later.
+```
+
+Show:
+
+```text
+Evidence saved
+Finding recorded
+Report generated
+```
+
+### 5. Show the report
+
+Open the generated Markdown report.
+
+Highlight sections:
+
+- summary,
+- finding title,
+- severity,
+- confidence,
+- reproduction status,
+- impact,
+- evidence references,
+- limitations.
+
+Say:
+
+```text
+This is the part that makes the tool useful. The result is not only a chat answer. It is a security artifact you can send, review, or improve.
+```
+
+### 6. Explain safety and limits
+
+Say this directly:
+
+```text
+Uxarion is for authorized testing. It is local-first and operator-driven. It is not a tool for attacking random public targets. It is useful when you own the target, have permission, or are working inside a legal lab or bug bounty scope.
+```
+
+This line protects the project and makes serious users trust you more.
+
+### 7. End with what is next
+
+Say:
+
+```text
+Next I am improving sample reports, Burp/ZAP workflows, and bug-bounty style exports. If you test web apps or are learning security, try the crAPI demo and open an issue with where the setup breaks.
+```
+
+## Exact video chapters
+
+```text
+00:00 Why security agents need scope
+00:35 Install and launch
+01:05 Target setup: crAPI local lab
+01:40 Scoped assessment prompt
+02:20 Discovery and account comparison
+03:20 Confirming an authorization issue
+04:20 Evidence capture
+05:00 Generated report
+06:00 Safety model and next steps
+```
+
+## Recording checklist
+
+Before recording:
+
+- update Uxarion to latest release,
+- use a fresh terminal profile,
+- increase terminal font size,
+- disable notifications,
+- prepare two crAPI accounts,
+- prepare MailHog if the demo needs email flows,
+- delete or hide old artifact paths,
+- do one full dry run without recording.
+
+During recording:
+
+- narrate the purpose of each step,
+- do not show API keys,
+- do not show real personal accounts,
+- do not test real public targets,
+- do not include long pauses.
+
+After recording:
+
+- cut dead time,
+- add chapter labels,
+- add captions,
+- export a 90-second cut and a 5-7 minute cut,
+- upload the long demo to YouTube or Loom,
+- use the short cut for X, LinkedIn, Reddit, and Hacker News.
+
+## Deep-dive post caption
+
+```text
+I made a longer technical walkthrough of Uxarion.
+
+The key idea: security agents should not just chat. They should run inside explicit target scope, preserve evidence, record findings, and generate a report from artifacts.
+
+Demo target: OWASP crAPI local lab.
+Repo: github.com/rachidlaad/uxarion
+```

--- a/docs/product-gap-review.md
+++ b/docs/product-gap-review.md
@@ -1,0 +1,212 @@
+# Uxarion product gap review
+
+This is the blunt review of what the repo needs before people care.
+
+## What is already strong
+
+- The repo has a simple install path: `npm install -g uxarion` and a direct installer.
+- The README already links to a demo video and states a concrete test target: OWASP crAPI running locally with MailHog.
+- The current pitch is clear enough for developers: Uxarion is an open-source terminal security assessment agent for local, operator-driven testing.
+- The codebase has real security-mode machinery: target scope, HTTP inspection, ZAP integration, evidence capture, findings, and report generation.
+- The project already has future-product issues around HackerOne integration, scratch automation workspace, and Burp Suite integration.
+
+## Hard truth
+
+The repo does not yet look like a product that creates urgency.
+
+It looks like a technically capable fork/tool. That is not enough. A stranger landing on the repo should understand in 10 seconds:
+
+1. what painful problem Uxarion solves,
+2. what exact result it produced,
+3. how to reproduce the result,
+4. what evidence/report comes out,
+5. why this is safer or more useful than asking a normal coding agent to hack around randomly.
+
+Right now, the README says those things, but it does not *show* them hard enough.
+
+## P0: add before any public push
+
+### 1. A visible proof table near the top of README
+
+Add a table like this:
+
+| Demo target | Result | Evidence | Report |
+| --- | --- | --- | --- |
+| OWASP crAPI local lab | 4 confirmed auth/state bugs | request/response evidence saved | Markdown pentest report generated |
+
+This makes the claim concrete.
+
+### 2. A reproducible demo tutorial
+
+Create one tutorial that a normal developer can run in under 15 minutes:
+
+- start crAPI locally,
+- start MailHog,
+- install Uxarion,
+- run one assessment prompt,
+- inspect saved evidence,
+- open the generated report.
+
+Without this, people will think the video is a one-off trick.
+
+### 3. A sample report folder
+
+Add a safe, sanitized example:
+
+```text
+examples/crapi-sample-report/
+  report.md
+  findings.json
+  evidence/
+    finding-0001-request.txt
+    finding-0001-response.txt
+```
+
+Do not expose secrets or tokens. Redact anything sensitive. The goal is not to publish exploit data; the goal is to show that Uxarion produces audit-grade evidence.
+
+### 4. A 90-second demo video
+
+The current demo link is useful, but public audiences need a shorter cut:
+
+- 0-10s: problem,
+- 10-25s: target and scope,
+- 25-55s: Uxarion finds the issue,
+- 55-75s: evidence is saved,
+- 75-90s: report is generated.
+
+Cut everything else.
+
+### 5. Clear safety positioning
+
+Add one simple section:
+
+> Uxarion is for authorized testing only. It binds sessions to declared scope, records evidence, and keeps operator control in the loop.
+
+This matters because security users need trust, and non-security viewers need to understand this is not reckless malware tooling.
+
+## P1: add after the first public push
+
+### 1. Better install matrix
+
+The README says `npm install -g uxarion`, and the direct shell installer supports Linux x64. The Windows direct installer currently exits and says direct Windows installation is not published yet. Make that status obvious so Windows users do not waste time.
+
+Suggested table:
+
+| Platform | Recommended install | Status |
+| --- | --- | --- |
+| Linux x64 | npm or install.sh | supported |
+| macOS | npm | supported through npm path |
+| Windows | npm / WSL path | direct install not published yet |
+
+### 2. "Why not just use ChatGPT/Codex?"
+
+You need this section because people will ask it.
+
+Answer:
+
+- Uxarion runs in a security mode.
+- It keeps target scope explicit.
+- It has security-specific tools.
+- It persists evidence and findings.
+- It generates a report from artifacts, not from memory.
+- It is local-first and operator-driven.
+
+### 3. Usage examples for three audiences
+
+Create separate examples:
+
+- bug bounty hunter on an authorized program,
+- startup developer checking their own staging app,
+- security student learning on crAPI/WebGoat/Juice Shop.
+
+Do not mix them. Mixed messaging kills conversion.
+
+### 4. Roadmap with proof-oriented milestones
+
+Bad roadmap: "AI pentesting platform."
+
+Good roadmap:
+
+- reproduce and report BOLA/IDOR in local labs,
+- generate HackerOne-style report from saved evidence,
+- import Burp/ZAP artifacts,
+- scoped program metadata integration,
+- CI-friendly report export.
+
+## P2: product features worth building
+
+### 1. Engagement wizard
+
+Add a first-run wizard:
+
+```text
+What are you testing?
+[1] Local lab
+[2] My own app
+[3] Authorized bug bounty scope
+[4] Internal pentest
+```
+
+Then ask for target URL, scope notes, auth state, and desired intensity.
+
+### 2. Demo mode
+
+Add `uxarion demo crapi` or a documented demo profile that starts with safe defaults and explains the steps.
+
+### 3. Sample artifact viewer
+
+Add a command that prints:
+
+```text
+Findings: 4
+Evidence files: 12
+Report: ~/.codex/security/<thread>/report.md
+```
+
+People love visible output.
+
+### 4. Report export polish
+
+Add a clean export path:
+
+```bash
+uxarion report export --format markdown
+uxarion report export --format pdf
+```
+
+PDF can come later, but the command shape should be obvious.
+
+### 5. Burp first, HackerOne second
+
+Burp integration will probably matter more immediately than HackerOne. HackerOne is attractive for the story, but Burp is where security people already live.
+
+## The positioning to use
+
+Use this line everywhere:
+
+> Uxarion is a local-first AI security agent that tests authorized web targets, saves evidence, and generates pentest-style reports.
+
+Do not pitch it as "AI pentesting" alone. That phrase is too vague and too crowded.
+
+## The next 7-day execution plan
+
+Day 1: Add sample crAPI report artifacts.
+
+Day 2: Record the 90-second demo.
+
+Day 3: Add README proof table and demo tutorial link.
+
+Day 4: Post the demo on X, LinkedIn, Reddit, and Hacker News.
+
+Day 5: DM 20 security students/bug bounty beginners and ask them to try the crAPI tutorial.
+
+Day 6: Fix installation friction from feedback.
+
+Day 7: Post a second demo focused only on the generated report.
+
+## What not to do
+
+- Do not rebuild the UI before proving demand.
+- Do not add ten integrations before one demo converts strangers.
+- Do not hide behind "still improving." Ship the proof.
+- Do not claim autonomous exploitation. Say operator-driven, scoped, evidence-backed.

--- a/docs/social-launch-pack.md
+++ b/docs/social-launch-pack.md
@@ -1,0 +1,223 @@
+# Uxarion social launch pack
+
+Use these posts after the 90-second demo is recorded. Do not post all of them at the same time. Spread them across one week.
+
+## Positioning line
+
+```text
+Uxarion is a local-first AI security agent for authorized web testing: scoped assessment, saved evidence, recorded findings, and generated reports.
+```
+
+## X / Twitter post 1: main demo
+
+```text
+I built Uxarion: a local-first AI security agent for authorized web testing.
+
+In this demo, it tests OWASP crAPI, confirms 4 authorization/state bugs, saves request/response evidence, and generates a pentest-style report.
+
+Open source: github.com/rachidlaad/uxarion
+```
+
+Attach: 90-second demo video.
+
+## X / Twitter post 2: harsh angle
+
+```text
+Most "AI pentesting" demos are just chat + curl.
+
+I want something stricter:
+- explicit target scope
+- operator-controlled testing
+- saved evidence
+- recorded findings
+- report generated from artifacts
+
+That is the direction of Uxarion.
+
+Repo: github.com/rachidlaad/uxarion
+```
+
+Attach: screenshot of report + evidence.
+
+## X / Twitter post 3: build-in-public
+
+```text
+9 months ago I started building in this direction and made the mistake of keeping too much of it private.
+
+Fixing that now.
+
+Uxarion is open source: a terminal AI security agent for authorized web testing, evidence capture, and report generation.
+
+Demo target: OWASP crAPI.
+```
+
+Attach: short clip or screenshot.
+
+## LinkedIn post
+
+```text
+I built Uxarion, an open-source local-first AI security agent for authorized web testing.
+
+The goal is simple: security workflows should not end as vague chat messages. A useful agent should operate inside explicit target scope, preserve evidence, record findings, and generate a report that can be reviewed later.
+
+In the demo, Uxarion runs against OWASP crAPI locally, confirms multiple authorization/state issues, saves request/response evidence, and generates a pentest-style Markdown report.
+
+Current focus:
+- scoped security assessment
+- local/operator-driven workflow
+- evidence capture
+- findings tracking
+- ZAP integration
+- report generation
+
+Repo: github.com/rachidlaad/uxarion
+
+I am looking for feedback from security students, bug bounty beginners, and developers who want to test their own apps safely.
+```
+
+Attach: 90-second demo video or report screenshot.
+
+## Hacker News title options
+
+Use one. Do not be cute.
+
+```text
+Show HN: Uxarion, a local-first AI security agent for authorized web testing
+```
+
+```text
+Show HN: I built an AI security agent that saves evidence and writes reports
+```
+
+```text
+Show HN: Uxarion – scoped AI-assisted web security testing from the terminal
+```
+
+## Hacker News body
+
+```text
+Hi HN,
+
+I built Uxarion, an open-source terminal security assessment agent for authorized web testing.
+
+The idea is to make AI-assisted security work more structured: explicit target scope, operator control, HTTP/ZAP-assisted testing, saved evidence, recorded findings, and report generation from artifacts.
+
+The current demo runs against OWASP crAPI locally and confirms authorization/state issues, including BOLA/IDOR-style problems, then generates a Markdown report.
+
+Repo: github.com/rachidlaad/uxarion
+
+I would especially appreciate feedback on:
+- install/setup friction,
+- whether the security workflow is clear,
+- what proof artifacts should be added,
+- whether Burp or HackerOne integration should come first.
+```
+
+## Reddit post for r/cybersecurity or r/bugbounty
+
+Check each subreddit rules before posting. Do not spam.
+
+```text
+Title: I built an open-source AI security agent for authorized web testing and report generation
+
+I have been building Uxarion, a local-first terminal security assessment agent.
+
+The goal is not "autonomous hacking." The goal is a scoped, operator-driven workflow where the agent helps inspect an authorized target, save evidence, record findings, and generate a report from artifacts.
+
+Current demo target: OWASP crAPI running locally.
+In the demo, Uxarion confirms multiple authorization/state issues, saves request/response evidence, and writes a pentest-style Markdown report.
+
+Repo: github.com/rachidlaad/uxarion
+
+I am looking for brutal feedback on:
+1. whether the repo explains the project clearly,
+2. where installation breaks,
+3. what evidence/report format would make it useful,
+4. whether Burp integration should come before HackerOne integration.
+
+This is for authorized testing only: local labs, owned apps, internal testing, or legal bug bounty scope.
+```
+
+## YouTube / Loom description
+
+```text
+Uxarion is an open-source local-first AI security agent for authorized web testing.
+
+In this demo, Uxarion runs against OWASP crAPI locally, focuses on authorization and state-management issues, saves evidence, records findings, and generates a pentest-style Markdown report.
+
+Repo: github.com/rachidlaad/uxarion
+Install: npm install -g uxarion
+
+This demo uses a deliberately vulnerable local lab. Do not test systems you do not own or do not have permission to assess.
+```
+
+## DM to security students / bug bounty beginners
+
+```text
+Hey, I built an open-source AI security agent called Uxarion.
+
+It is designed for authorized web testing: scope, evidence, findings, and report generation.
+
+I am testing the crAPI demo flow and need brutal feedback on setup friction and whether the output is useful.
+
+Repo: github.com/rachidlaad/uxarion
+
+Can you try the demo on a local lab and tell me where it breaks or feels unclear?
+```
+
+## DM to developers with their own apps
+
+```text
+Hey, I am building Uxarion, a local-first AI security agent for authorized web testing.
+
+The goal is to help developers test their own apps/staging environments and get evidence-backed findings instead of vague AI advice.
+
+Repo: github.com/rachidlaad/uxarion
+
+I am looking for feedback on whether the workflow is understandable and whether the generated report would be useful to a developer team.
+```
+
+## Posting schedule
+
+Day 1:
+- X main demo
+- LinkedIn demo
+
+Day 2:
+- DM 10 security students or bug bounty beginners
+
+Day 3:
+- Reddit feedback post
+
+Day 4:
+- X harsh angle post
+
+Day 5:
+- Hacker News Show HN
+
+Day 6:
+- DM 10 developers/startup builders
+
+Day 7:
+- Post the report-focused demo: "AI security agent writes a report from saved evidence"
+
+## Metrics to track
+
+Track these manually in a simple table:
+
+| Channel | Views | Clicks | Stars | Installs | Feedback replies | Real users |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| X | | | | | | |
+| LinkedIn | | | | | | |
+| Reddit | | | | | | |
+| HN | | | | | | |
+| DMs | | | | | | |
+
+The only metrics that matter early:
+
+1. Did strangers click?
+2. Did strangers install?
+3. Did strangers run the demo?
+4. Did strangers complain about something specific?
+
+Ignore likes if nobody tries it.


### PR DESCRIPTION
## Summary

Adds a docs-based public demo pack so Uxarion can be shown clearly to strangers instead of staying as a technical repo.

Included:

- product gap review with the most important missing proof assets
- 90-second crAPI demo script
- 5-7 minute technical deep-dive demo script
- social launch pack for X, LinkedIn, Hacker News, Reddit, and DMs
- demo assets checklist
- docs index for the demo pack

## Why

The repo already has a real security-agent direction, demo claim, install path, evidence/finding/report concepts, ZAP integration, and safety scope logic. The missing piece is public packaging: reproducible proof, short demo, sample output, and distribution copy.

## Safety note

All demo guidance is framed around authorized targets, local labs, owned apps, internal testing, or legal bug bounty scope. No public-target testing instructions are included.

## Next after this PR

- Add sanitized sample crAPI report artifacts
- Add a README proof table near the top
- Record the 90-second crAPI demo
- Post the demo and collect installation feedback